### PR TITLE
Fix error message for bad input in GEARS.predict()

### DIFF
--- a/gears/gears.py
+++ b/gears/gears.py
@@ -217,7 +217,7 @@ class GEARS:
             for i in pert:
                 if i not in self.pert_list:
                     raise ValueError(i+ " is not in the perturbation graph. "
-                                        "Please select from GEARS.gene_list!")
+                                        "Please select from GEARS.pert_list!")
         
         if self.config['uncertainty']:
             results_logvar = {}


### PR DESCRIPTION
An error message, gears.py L220, previously read "Please select from GEARS.gene_list", but the code checks GEARS.pert_list, not GEARS.gene_list. I updated the error message to point users to GEARS.pert_list. 