### PR TITLE
Add support for perturbation magnitude/direction

### DIFF
--- a/gears/utils.py
+++ b/gears/utils.py
@@ -12,7 +12,27 @@ import tarfile
 from sklearn.linear_model import TheilSenRegressor
 from dcor import distance_correlation
 from multiprocessing import Pool
-from functools import partial
+
+
+# Measured as "percent relative to control", e.g. 100 is the same as control,
+# 200 is a 2X overexpression, 20 is 5X underexpression, 0 is knockout.
+DEFAULT_MAGNITUDE = 100
+
+def rm_magnitude(gene_with_magnitude: str) -> str:
+    return gene_with_magnitude.split('*')[0]
+
+def get_pert_genes(pert: list[str]) -> list[str]:
+    # Remove perturbation mangnitude.
+    # TODO: can be combined with `get_genes_from_perts`
+    return [rm_magnitude(g) for g in pert.split('+')]
+
+def get_pert_magnitude(pert: str) -> list[int]:
+    # Returns magnitudes for genes in `pert`.
+    return [
+        int(gene.split('*')[-1]) if '*' in gene else DEFAULT_MAGNITUDE
+        for gene in pert.split('+')
+        if gene != 'ctrl'
+    ]
 
 def parse_single_pert(i):
     a = i.split('+')[0]
@@ -21,10 +41,10 @@ def parse_single_pert(i):
         pert = b
     else:
         pert = a
-    return pert
+    return rm_magnitude(pert)
 
 def parse_combo_pert(i):
-    return i.split('+')[0], i.split('+')[1]
+    return get_pert_genes(i)[:2]
 
 def combine_res(res_1, res_2):
     res_out = {}
@@ -56,7 +76,7 @@ def dataverse_download(url, save_path):
         url (str): the url of the dataset
         path (str): the path to save the dataset
     """
-    
+
     if os.path.exists(save_path):
         print_sys('Found local copy...')
     else:
@@ -71,7 +91,7 @@ def dataverse_download(url, save_path):
                 file.write(data)
         progress_bar.close()
 
-        
+
 def zip_data_download_wrapper(url, save_path, data_path):
 
     if os.path.exists(save_path):
@@ -81,8 +101,8 @@ def zip_data_download_wrapper(url, save_path, data_path):
         print_sys('Extracting zip file...')
         with ZipFile((save_path + '.zip'), 'r') as zip:
             zip.extractall(path = data_path)
-        print_sys("Done!")  
-        
+        print_sys("Done!")
+
 def tar_data_download_wrapper(url, save_path, data_path):
 
     if os.path.exists(save_path):
@@ -92,11 +112,11 @@ def tar_data_download_wrapper(url, save_path, data_path):
         print_sys('Extracting tar file...')
         with tarfile.open(save_path  + '.tar.gz') as tar:
             tar.extractall(path= data_path)
-        print_sys("Done!")  
-        
+        print_sys("Done!")
+
 def get_go_auto(gene_list, data_path, data_name):
     go_path = os.path.join(data_path, data_name, 'go.csv')
-    
+
     if os.path.exists(go_path):
         return pd.read_csv(go_path)
     else:
@@ -123,7 +143,7 @@ def get_go_auto(gene_list, data_path, data_name):
         df_edge_list = df_edge_list.rename(columns = {'gene1': 'source',
                                                       'gene2': 'target',
                                                       'score': 'importance'})
-        df_edge_list.to_csv(go_path, index = False)        
+        df_edge_list.to_csv(go_path, index = False)
         return df_edge_list
 
 def get_go(df_gene2go):
@@ -162,18 +182,18 @@ class GeneSimNetwork():
         self.edge_list = edge_list
         self.G = nx.from_pandas_edgelist(self.edge_list, source='source',
                         target='target', edge_attr=['importance'],
-                        create_using=nx.DiGraph())    
+                        create_using=nx.DiGraph())
         self.gene_list = gene_list
         for n in self.gene_list:
             if n not in self.G.nodes():
                 self.G.add_node(n)
-        
+
         edge_index_ = [(node_map[e[0]], node_map[e[1]]) for e in
                       self.G.edges]
         self.edge_index = torch.tensor(edge_index_, dtype=torch.long).T
         #self.edge_weight = torch.Tensor(self.edge_list['importance'].values)
-        
-        edge_attr = nx.get_edge_attributes(self.G, 'importance') 
+
+        edge_attr = nx.get_edge_attributes(self.G, 'importance')
         importance = np.array([edge_attr[e] for e in self.G.edges])
         self.edge_weight = torch.Tensor(importance)
 
@@ -186,7 +206,7 @@ def get_GO_edge_list(args):
         if score > 0.1:
             edge_list.append((g1, g2, score))
     return edge_list
-        
+
 def make_GO(data_path, pert_list, data_name, num_workers=25, save=True):
     """
     Creates Gene Ontology graph from a custom set of genes
@@ -211,7 +231,7 @@ def make_GO(data_path, pert_list, data_name, num_workers=25, save=True):
 
     df_edge_list = pd.DataFrame(edge_list).rename(
         columns={0: 'source', 1: 'target', 2: 'importance'})
-    
+
     if save:
         print('Saving edge_list to file')
         df_edge_list.to_csv(fname, index=False)
@@ -220,24 +240,28 @@ def make_GO(data_path, pert_list, data_name, num_workers=25, save=True):
 
 def get_similarity_network(network_type, adata, threshold, k,
                            data_path, data_name, split, seed, train_gene_set_size,
-                           set2conditions, default_pert_graph=True, pert_list=None):
-    
+                           set2conditions, default_pert_graph=True, pert_list=None,
+                           go_path: str = None):
+
     if network_type == 'co-express':
         df_out = get_coexpression_network_from_train(adata, threshold, k,
                                                      data_path, data_name, split,
                                                      seed, train_gene_set_size,
                                                      set2conditions)
     elif network_type == 'go':
-        if default_pert_graph:
-            server_path = 'https://dataverse.harvard.edu/api/access/datafile/6934319'
-            tar_data_download_wrapper(server_path, 
-                                     os.path.join(data_path, 'go_essential_all'),
-                                     data_path)
-            df_jaccard = pd.read_csv(os.path.join(data_path, 
-                                     'go_essential_all/go_essential_all.csv'))
-
+        if go_path is not None:
+            df_jaccard = pd.read_csv(go_path)
+            print_sys(f'Loaded {len(df_jaccard)} similarities from {go_path}')
         else:
-            df_jaccard = make_GO(data_path, pert_list, data_name)
+            if default_pert_graph:
+                server_path = 'https://dataverse.harvard.edu/api/access/datafile/6934319'
+                tar_data_download_wrapper(server_path,
+                                        os.path.join(data_path, 'go_essential_all'),
+                                        data_path)
+                df_jaccard = pd.read_csv(os.path.join(data_path,
+                                        'go_essential_all/go_essential_all.csv'))
+            else:
+                df_jaccard = make_GO(data_path, pert_list, data_name)
 
         df_out = df_jaccard.groupby('target').apply(lambda x: x.nlargest(k + 1,
                                     ['importance'])).reset_index(drop = True)
@@ -247,17 +271,17 @@ def get_similarity_network(network_type, adata, threshold, k,
 def get_coexpression_network_from_train(adata, threshold, k, data_path,
                                         data_name, split, seed, train_gene_set_size,
                                         set2conditions):
-    
+
     fname = os.path.join(os.path.join(data_path, data_name), split + '_'  +
                          str(seed) + '_' + str(train_gene_set_size) + '_' +
                          str(threshold) + '_' + str(k) +
                          '_co_expression_network.csv')
-    
+
     if os.path.exists(fname):
         return pd.read_csv(fname)
     else:
         gene_list = [f for f in adata.var.gene_name.values]
-        idx2gene = dict(zip(range(len(gene_list)), gene_list)) 
+        idx2gene = dict(zip(range(len(gene_list)), gene_list))
         X = adata.X
         train_perts = set2conditions['train']
         X_tr = X[np.isin(adata.obs.condition, [i for i in train_perts if 'ctrl' in i])]
@@ -283,23 +307,22 @@ def get_coexpression_network_from_train(adata, threshold, k, data_path,
                                                                 2: 'importance'})
         df_co_expression.to_csv(fname, index = False)
         return df_co_expression
-    
+
 def filter_pert_in_go(condition, pert_names):
     if condition == 'ctrl':
         return True
     else:
-        cond1 = condition.split('+')[0]
-        cond2 = condition.split('+')[1]
+        cond1, cond2 = get_pert_genes(condition)[:2]
         num_ctrl = (cond1 == 'ctrl') + (cond2 == 'ctrl')
         num_in_perts = (cond1 in pert_names) + (cond2 in pert_names)
         if num_ctrl + num_in_perts == 2:
             return True
         else:
             return False
-        
+
 def uncertainty_loss_fct(pred, logvar, y, perts, reg = 0.1, ctrl = None,
                          direction_lambda = 1e-3, dict_filter = None):
-    gamma = 2                     
+    gamma = 2
     perts = np.array(perts)
     losses = torch.tensor(0.0, requires_grad=True).to(pred.device)
     for p in set(perts):
@@ -312,12 +335,12 @@ def uncertainty_loss_fct(pred, logvar, y, perts, reg = 0.1, ctrl = None,
             pred_p = pred[np.where(perts==p)[0]]
             y_p = y[np.where(perts==p)[0]]
             logvar_p = logvar[np.where(perts==p)[0]]
-                         
+
         # uncertainty based loss
         losses += torch.sum((pred_p - y_p)**(2 + gamma) + reg * torch.exp(
             -logvar_p)  * (pred_p - y_p)**(2 + gamma))/pred_p.shape[0]/pred_p.shape[1]
-                         
-        # direction loss                 
+
+        # direction loss
         if p!= 'ctrl':
             losses += torch.sum(direction_lambda *
                                 (torch.sign(y_p - ctrl[retain_idx]) -
@@ -328,7 +351,7 @@ def uncertainty_loss_fct(pred, logvar, y, perts, reg = 0.1, ctrl = None,
                                 (torch.sign(y_p - ctrl) -
                                  torch.sign(pred_p - ctrl))**2)/\
                                  pred_p.shape[0]/pred_p.shape[1]
-            
+
     return losses/(len(set(perts)))
 
 
@@ -340,7 +363,7 @@ def loss_fct(pred, y, perts, ctrl = None, direction_lambda = 1e-3, dict_filter =
 
     for p in set(perts):
         pert_idx = np.where(perts == p)[0]
-        
+
         # during training, we remove the all zero genes into calculation of loss.
         # this gives a cleaner direction loss. empirically, the performance stays the same.
         if p!= 'ctrl':
@@ -352,7 +375,7 @@ def loss_fct(pred, y, perts, ctrl = None, direction_lambda = 1e-3, dict_filter =
             y_p = y[pert_idx]
         #losses += torch.sum((torch.mean(pred_p, 0) - y_p)**(2+gamma))/pred_p.shape[1]
         losses = losses + torch.sum((pred_p - y_p)**(2 + gamma))/pred_p.shape[0]/pred_p.shape[1]
-                         
+
         ## direction loss
         if (p!= 'ctrl'):
             losses = losses + torch.sum(direction_lambda *
@@ -373,20 +396,21 @@ def print_sys(s):
         s (str): the string to print
     """
     print(s, flush = True, file = sys.stderr)
-    
+
 def create_cell_graph_for_prediction(X, pert_idx, pert_gene):
 
     if pert_idx is None:
         pert_idx = [-1]
-    return Data(x=torch.Tensor(X).T, pert_idx = pert_idx, pert=pert_gene)
-    
+    pert_magnitude = [get_pert_magnitude(g)[0] for g in pert_gene]
+    return Data(x=torch.Tensor(X).T, pert_idx=pert_idx, pert=pert_gene, pert_magnitude=pert_magnitude)
+
 
 def create_cell_graph_dataset_for_prediction(pert_gene, ctrl_adata, gene_names,
                                              device, num_samples = 300):
 
     # Get the indices (and signs) of applied perturbation
-    pert_idx = [np.where(p == np.array(gene_names))[0][0] for p in pert_gene]
-
+    pert_gene_no_magnitude = [rm_magnitude(p) for p in pert_gene]
+    pert_idx = [np.where(p == np.array(gene_names))[0][0] for p in pert_gene_no_magnitude]
     Xs = ctrl_adata[np.random.randint(0, len(ctrl_adata), num_samples), :].X.toarray()
     # Create cell graphs
     cell_graphs = [create_cell_graph_for_prediction(X, pert_idx, pert_gene).to(device) for X in Xs]
@@ -401,7 +425,7 @@ def get_coeffs(singles_expr, first_expr, second_expr, double_expr):
     results['ts'] = TheilSenRegressor(fit_intercept=False,
                           max_subpopulation=1e5,
                           max_iter=1000,
-                          random_state=1000)   
+                          random_state=1000)
     X = singles_expr
     y = double_expr
     results['ts'].fit(X, y.ravel())
@@ -409,7 +433,7 @@ def get_coeffs(singles_expr, first_expr, second_expr, double_expr):
     results['c1'] = results['ts'].coef_[0]
     results['c2'] = results['ts'].coef_[1]
     results['mag'] = np.sqrt((results['c1']**2 + results['c2']**2))
-    
+
     results['dcor'] = distance_correlation(singles_expr, double_expr)
     results['dcor_singles'] = distance_correlation(first_expr, second_expr)
     results['dcor_first'] = distance_correlation(first_expr, double_expr)
@@ -418,23 +442,23 @@ def get_coeffs(singles_expr, first_expr, second_expr, double_expr):
     results['dominance'] = np.abs(np.log10(results['c1']/results['c2']))
     results['eq_contr'] = np.min([results['dcor_first'], results['dcor_second']])/\
                         np.max([results['dcor_first'], results['dcor_second']])
-    
+
     return results
 
 def get_GI_params(preds, combo):
-    
+
     singles_expr = np.array([preds[combo[0]], preds[combo[1]]]).T
     first_expr = np.array(preds[combo[0]]).T
     second_expr = np.array(preds[combo[1]]).T
     double_expr = np.array(preds[combo[0]+'_'+combo[1]]).T
-    
+
     return get_coeffs(singles_expr, first_expr, second_expr, double_expr)
 
 def get_GI_genes_idx(adata, GI_gene_file):
     # Genes used for linear model fitting
     GI_genes = np.load(GI_gene_file, allow_pickle=True)
     GI_genes_idx = np.where([g in GI_genes for g in adata.var.gene_name.values])[0]
-    
+
     return GI_genes_idx
 
 def get_mean_control(adata):


### PR DESCRIPTION
Modifies perturbation names to include an optional magnitude, separated from the gene name by `*`, i.e. `p53*200`, `brca2*0`. The magnitude is an integer, interpreted as a percentage change from base (i.e. 0 is a knockout), and is used to multiply the perturbation embedding. If no magnitude is provided, a default one of 100% is used (to be backward-compatible with the current implementation).

Many of the changes are trailing-whitespace removals from an auto-formatter; the only real modifications are parsing and storing an additional `pert_magnitude` array with the rest of the data and using it to modify the embedding.