### PR TITLE
Address a potential problem while creating a training dataset with dense array inputs

### DIFF
--- a/gears/data_utils.py
+++ b/gears/data_utils.py
@@ -81,7 +81,12 @@ def get_dropout_non_zero_genes(adata):
     for i, j in conditions2index.items():
         condition2mean_expression[i] = np.mean(adata.X[j], axis = 0)
     pert_list = np.array(list(condition2mean_expression.keys()))
-    mean_expression = np.array(list(condition2mean_expression.values())).reshape(len(adata.obs.condition.unique()), adata.X.toarray().shape[1])
+    # to handle the non-sparse data input
+    try :
+        adata.X = adata.X.toarray()
+        mean_expression = np.array(list(condition2mean_expression.values())).reshape(len(adata.obs.condition.unique()), adata.X.shape[1])
+    except:
+        mean_expression = np.array(list(condition2mean_expression.values())).reshape(len(adata.obs.condition.unique()), adata.X.shape[1])
     ctrl = mean_expression[np.where(pert_list == 'ctrl')[0]]
     
     ## in silico modeling and upperbounding

--- a/gears/pertdata.py
+++ b/gears/pertdata.py
@@ -594,8 +594,13 @@ class PertData:
         # Create cell graphs
         cell_graphs = []
         for X, y in zip(Xs, ys):
-            cell_graphs.append(self.create_cell_graph(X.toarray(),
-                                y.toarray(), de_idx, pert_category, pert_idx))
+            try:
+                cell_graphs.append(self.create_cell_graph(X.toarray(),
+                                    y, de_idx, pert_category, pert_idx))
+            except:
+                y = y.toarray()
+                cell_graphs.append(self.create_cell_graph(X.toarray(),
+                                    y, de_idx, pert_category, pert_idx))
 
         return cell_graphs
 


### PR DESCRIPTION
Hi, I notice that the current pre-processing step for creating the dataset assumes input data are formed as sparse data (adata.X is sparse matrix), so if the input data form as dense matrix, there will be an error:

<img width="1013" alt="image" src="https://github.com/snap-stanford/GEARS/assets/43333475/fc3e328f-6b47-4045-92e0-27e7efa9968b">

Therefore, I modify the current codes which will be suitable for either sparse matrix or dense matrix as inputs.

Moreover, I also notice that gears will compute DEGs for the further work related to metrics, but if there is only one cell under such perturbation, an error will be thrown:

<img width="967" alt="image" src="https://github.com/snap-stanford/GEARS/assets/43333475/a355e359-ae2f-4dbf-b8cc-f88774db4e9f">

Therefore, I also recommend modifying the tutorial to warn such condition. Thanks.